### PR TITLE
Egressor Fix

### DIFF
--- a/toolbox/egress_prism_input_data.py
+++ b/toolbox/egress_prism_input_data.py
@@ -43,6 +43,40 @@ def write_out(df, fp, delim=",", fmt="csv"):
   dbutils.fs.cp(temporary_fp, fp)
   dbutils.fs.rm(temp_target, recurse=True)
 
+# COMMAND ----------
+
+#Check if the receipt files has been created already.
+#If so, that means that means the egressor ran.
+today = dt.datetime.today().strftime('%Y%m%d')
+#Commented line below was used to test code.
+#today = "20241016"
+receipt_fp = (
+  "abfss://media@sa8451dbxadhocprd.dfs.core.windows.net/audience_factory/egress_receipts/" +
+  "egress_{}.csv".format(today)
+)
+
+#If receipt_fp exists, then we will add 1 to i.
+i = 0
+try:
+  #Below will throw an error if the filepath does NOT exists.
+  dbutils.fs.ls(receipt_fp)
+  i += 1
+except:
+  #Error was triggered b/c filepath does NOT exists (as expected).
+  message = f"No egress receipt detected for today ({today})."
+  print(message)
+  del(message)
+
+if i > 0:
+  #dbutils.fs.ls() executed successfully. Implies that egressor was run today. Abort the current run.
+  message = f"{receipt_fp} exists. The egressor was already executed today. Aborting execution."
+  raise ValueError(message)
+
+#Directory where all files are written out as parquet to be egressed.
+egress_dir = "abfss://media@sa8451dbxadhocprd.dfs.core.windows.net/audience_factory/egress"
+
+# COMMAND ----------
+
 #Get all productionized segmentations
 segs = con.segmentations.all_segmentations
 segs.sort()
@@ -86,8 +120,6 @@ for seg in segs:
     continue
     
   #Write out to the egress directory and write out in format that engineering expects
-  egress_dir = "abfss://media@sa8451dbxadhocprd.dfs.core.windows.net/audience_factory/egress"
-  today = dt.datetime.today().strftime('%Y%m%d')
   dest_fp = egress_dir + '/' + seg + '/' + seg + '_' + today
   df.write.mode("overwrite").format("parquet").save(dest_fp)
   print("SUCCESS - Wrote out to {}!\n\n".format(dest_fp))


### PR DESCRIPTION
Added quality check that will check if the egressor was run already before proceeding. If so, then the notebook is aborted. This is to avoid the errors produced by triggering the egressor multiple times on the same day.

The issue is NOT the act of egressing. The root cause is when the given audience has had its file egressed multiple times in one day. That is because when that file lands at /data/marts/comms/prd/KrogerSegments/<audience>/<audience>_<YYYYMMDD>, that file has duplicated files for each partition.

Even with the added code, a dumb-dumb (like me) can still cause the error by simply not utilizing egress_prism_input and writing out to the egress directory directly. At the very least, the code chunk will prevent the user from causing the error for ALL the audiences. That is a much worse issue.